### PR TITLE
[render preview] Spanish transcription language hint (Wave 3-prep)

### DIFF
--- a/backend/routes/api/integrations/twilio.js
+++ b/backend/routes/api/integrations/twilio.js
@@ -195,11 +195,15 @@ router.post('/recordingStatus', urlencodedParser, (req, res) => {
             });
         }
 
-        // 6) Transcribir con OpenAI (externo → log, NO bloquea)
+       // 6) Transcribir con OpenAI (externo → log, NO bloquea)
+        // Wave 3-prep: infer Spanish from area code so gpt-4o-transcribe
+        // gets an explicit language hint for Miami-area callers. Only
+        // applies when SPANISH_LANGUAGE_HINT_ENABLED=true; otherwise the
+        // hint is silently ignored and we fall back to auto-detect.
+        const langHint = inferSpanishFromPhone(call?.from) || inferSpanishFromPhone(call?.to);
         const aiRes = await bestEffort('openai', 'transcribe_audio', ctx, async () => {
-            return getTranscriptionFromRecording(stream);
+            return getTranscriptionFromRecording(stream, { languageHint: langHint });
         });
-
         if (aiRes.ok && aiRes.result) {
             // Guardar transcription local (best-effort)
             await bestEffort('db', 'update_recording_transcription', ctx, async () => {
@@ -316,6 +320,23 @@ function extractDialedNumber(toVal) {
 
     // If you support other countries, you should handle your own rules here.
     return null;
+}
+
+// Wave 3-prep: heuristic for inferring caller language from phone number.
+// South Florida area codes (305 Miami-Dade, 786 Miami-Dade, 954 Broward,
+// 561 Palm Beach) where Spanish-as-first-language is dominant in
+// S.M.A.R.T Solutions' dental client base. Returns 'es' or null.
+// Conservative: only returns a hint if confident — auto-detect remains
+// the fallback for any number not in this set.
+function inferSpanishFromPhone(phoneNumber) {
+    if (!phoneNumber) return null;
+    const digits = String(phoneNumber).replace(/\D/g, '');
+    // E.164 like +13055551212 → strip leading 1 if NANP
+    const local = digits.startsWith('1') && digits.length === 11 ? digits.slice(1) : digits;
+    if (local.length < 10) return null;
+    const areaCode = local.slice(0, 3);
+    const SPANISH_DOMINANT = new Set(['305', '786', '954', '561']);
+    return SPANISH_DOMINANT.has(areaCode) ? 'es' : null;
 }
 
 module.exports = { router, publicWebhookPaths };

--- a/backend/utils/openai.js
+++ b/backend/utils/openai.js
@@ -32,21 +32,32 @@ async function getTitleAndDescription(transcription, anonymous = false) {
     return { title: '', description: '' };
 }
 
-async function getTranscriptionFromRecording(file) {
-    const client = new OpenAI({ apiKey: openaiApiKey });
+// Wave 3-prep: env-flag gate for Spanish-aware transcription.
+// When SPANISH_LANGUAGE_HINT_ENABLED=true AND opts.languageHint is provided
+// (typically 'es' inferred from Miami area codes in twilio.js), pass
+// language explicitly to gpt-4o-transcribe. This is OpenAI's documented
+// fix for the auto-detect-misfires-on-Spanish problem.
+const SPANISH_HINT_ENABLED = String(process.env.SPANISH_LANGUAGE_HINT_ENABLED || '').toLowerCase() === 'true';
 
-    // const audioUrl = recordingUrl.replace(/\.[^/.]+$/, '') + '.mp3';
-    // console.info('getTranscriptionFromRecording - audioUrl: ' + audioUrl);
+async function getTranscriptionFromRecording(file, opts = {}) {
+    const client = new OpenAI({ apiKey: openaiApiKey });
 
     let transcription = null;
 
     try {
-        const response = await client.audio.transcriptions.create({
+        const params = {
             file: file,
             model: "gpt-4o-transcribe",
             response_format: "text",
-            prompt: "Here is an audio file. All my audio files are IT support calls where a client reports a technical issue and a help-desk technician provides troubleshooting. Please transcribe the call verbatim with proper punctuation, and label the speakers as Client and Technician. Automatically detect the language spoken in the audio and provide the transcript in that same language, whether it is English, Spanish, or Spanglish. Add timestamps every 30 seconds and mark unclear audio with ‘[inaudible]’. After the transcript, provide a concise help-desk analysis that includes: 1) the main issue reported by the client, 2) the probable root cause, 3) the troubleshooting steps taken during the call, and 4) recommended next steps or follow-up actions. Do not summarize the transcript itself—only provide the analysis after the full transcript.",
-        });
+            prompt: "Here is an audio file. All my audio files are IT support calls where a client reports a technical issue and a help-desk technician provides troubleshooting. Please transcribe the call verbatim with proper punctuation, and label the speakers as Client and Technician. Automatically detect the language spoken in the audio and provide the transcript in that same language, whether it is English, Spanish, or Spanglish. Add timestamps every 30 seconds and mark unclear audio with '[inaudible]'. After the transcript, provide a concise help-desk analysis that includes: 1) the main issue reported by the client, 2) the probable root cause, 3) the troubleshooting steps taken during the call, and 4) recommended next steps or follow-up actions. Do not summarize the transcript itself—only provide the analysis after the full transcript.",
+        };
+
+        if (SPANISH_HINT_ENABLED && opts.languageHint) {
+            params.language = opts.languageHint;   // e.g. "es"
+            console.info(`getTranscriptionFromRecording: using languageHint=${opts.languageHint}`);
+        }
+
+        const response = await client.audio.transcriptions.create(params);
 
         console.info('getTranscriptionFromRecording:\n' + JSON.stringify(response));
 


### PR DESCRIPTION
## Wave 3-prep: Spanish-aware transcription (raw transcript only)

One small change to fix Spanish transcript accuracy, env-flag gated.
Freshservice ticket UI is intentionally NOT changed — title + description
stay English for agent workflow consistency.

### Problem
`getTranscriptionFromRecording` calls gpt-4o-transcribe without a
`language` parameter. Auto-detect misfires on Spanish/Spanglish calls,
especially when calls open with English greeting before Spanish customer
speech. Result: degraded transcripts for ~30-50% of our calls.

### Solution
- Pass `language: "es"` to gpt-4o-transcribe when caller's area code is
  Miami metro (305 / 786 / 954 / 561). Other area codes unchanged
  (auto-detect remains).
- Gated behind new env var `SPANISH_LANGUAGE_HINT_ENABLED` (default `false`).
- `getTitleAndDescription` INTENTIONALLY unchanged — Freshservice ticket
  title + description continue to be generated in English, per operational
  preference that agent-facing Freshservice content stays consistent in
  English.

### What changes (and what doesn't)
| Layer | Before | After PATCH 1 |
|---|---|---|
| Twilio recording | Spanish audio | unchanged |
| Raw transcript (`TwilioCall.transcription`) | Often degraded for Spanish | Accurate Spanish |
| Freshservice ticket subject | English | **English (unchanged)** |
| Freshservice ticket description | English | **English (unchanged)** |
| Cuko compliance evaluation | Uses lossy transcript | Uses accurate Spanish transcript |
| Future Wave 3d/4 knowledge graph | Lossy input | Accurate input |

### Files changed
- `backend/utils/openai.js` — `getTranscriptionFromRecording` function adds optional `opts.languageHint` parameter
- `backend/routes/api/integrations/twilio.js` — `recordingStatus` infers `langHint` from caller area code + new `inferSpanishFromPhone` helper

### Env var required
Add `SPANISH_LANGUAGE_HINT_ENABLED=false` to Render Environment BEFORE merging.
Flip to `true` post-deploy when ready to activate.

### Testing on Render Preview
- [ ] Render preview deploy spawned at `ticket-flow-pr-N.onrender.com`
- [ ] Preview env has `SPANISH_LANGUAGE_HINT_ENABLED=true` for testing
- [ ] Test with a known Spanish recording → confirm `language: "es"` in OpenAI logs
- [ ] Verify `getTitleAndDescription` output is still English regardless of transcript language
- [ ] Smoke test: existing English call → behavior unchanged

### Rollback
1. Quickest: Render → Environment → `SPANISH_LANGUAGE_HINT_ENABLED=false` → Save. ~30s, no redeploy.
2. Full revert: GitHub → Revert this PR → merge revert → manual deploy.

### Wave 3 context
Wave 3a (post-GN100 hardware, expected this week) will replace OpenAI
transcription entirely with local Whisper large-v3. This PR is the bridge
fix — improves Spanish accuracy immediately without waiting for the local
stack to land. The accurate Spanish transcripts produced after this PR
ships will feed the future GN100 knowledge graph (Wave 3d).